### PR TITLE
Added ServiceAccount and RBAC for dev-container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,19 +146,19 @@ bin/kubectl: .versions/kubernetes | bin/devctl
 	@touch $@
 
 .make/shulker-install: hack/shulker-values.yml .make/agones-install | bin/kubectl .make/kind-cluster .make/${SHULKER_NS}
-	$(HELM) install ${SHULKER_RELEASE} \
+	[ ! -f $@ ] && $(HELM) install ${SHULKER_RELEASE} \
 	--repo https://jeremylvln.github.io/Shulker/helm-charts \
 	--namespace ${SHULKER_NS} \
 	--values hack/shulker-values.yml \
-	--hide-notes shulker-operator
+	--hide-notes shulker-operator || true
 	@touch $@
 
 .make/agones-install: hack/agones-values.yml | bin/kubectl .make/kind-cluster .make/${SHULKER_NS}
-	$(HELM) install ${AGONES_RELEASE} \
+	[ ! -f $@ ] && $(HELM) install ${AGONES_RELEASE} \
 	--repo https://agones.dev/chart/stable \
 	--namespace ${AGONES_NS} --create-namespace \
 	--values hack/agones-values.yml \
-	--hide-notes agones
+	--hide-notes agones || true
 	@touch $@
 
 .make/agones-uninstall: .make/shulker-uninstall

--- a/hack/dev-container.yml
+++ b/hack/dev-container.yml
@@ -23,3 +23,37 @@ spec:
     - name: src
       hostPath:
         path: /src
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dev-container
+automountServiceAccountToken: true
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: dev-container
+rules:
+  - apiGroups:
+      - shulkermc.io
+    resources:
+      - minecraftclusters
+      - minecraftserverfleets
+      - minecraftservers
+      - proxyfleets
+    verbs: [get, list, watch, update, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: dev-container
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: dev-container
+subjects:
+  - apiGroup: ""
+    kind: ServiceAccount
+    name: dev-container
+    namespace: default


### PR DESCRIPTION
The update includes the addition of a new ServiceAccount named 'dev-container' with token auto-mount enabled. Also, a ClusterRole and ClusterRoleBinding have been created for this service account to provide necessary permissions on specific resources. The permissions include get, list, watch, update, and patch operations on minecraftclusters, minecraftserverfleets, minecraftservers, and proxyfleets under the shulkermc.io API group.